### PR TITLE
Set textbox styles as important

### DIFF
--- a/dracula.scss
+++ b/dracula.scss
@@ -27,9 +27,9 @@
 }
 /* chat box*/
 .scrollableContainer-15eg7h {
-	border-radius: 25px;
-	border: 1px solid var(--dracula-tertiary);
-	background-color: var(--dracula-secondary);
+	border-radius: 25px !important;
+	border: 1px solid var(--dracula-tertiary) !important;
+	background-color: var(--dracula-secondary) !important;
 }
 /* date divider */
 .content-3spvdd {


### PR DESCRIPTION
As found during inspection, Discord added a new theme-dark style that overrides the container style. Adding important to fix the theme.

Newly added style by Discord to be overridden:
`.theme-dark .scrollableContainer-15eg7h {
    /* background: var(--bg-overlay-3,var(--channeltextarea-background)); */
}`